### PR TITLE
Fix issue #34: Google chrome autofill is displayed over autocomplete results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,9 +58,28 @@ var ReactGoogleAutocomplete = function (_React$Component) {
         config.componentRestrictions = componentRestrictions;
       }
 
+      this.disableAutofill();
+
       this.autocomplete = new google.maps.places.Autocomplete(this.refs.input, config);
 
       this.event = this.autocomplete.addListener('place_changed', this.onSelected.bind(this));
+    }
+  }, {
+    key: 'disableAutofill',
+    value: function disableAutofill() {
+      var _this2 = this;
+
+      // Autofill workaround adapted from https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445
+      if (window.MutationObserver) {
+        var observerHack = new MutationObserver(function () {
+          observerHack.disconnect();
+          _this2.refs.input.autocomplete = 'disable-autofill';
+        });
+        observerHack.observe(this.refs.input, {
+          attributes: true,
+          attributeFilter: ['autocomplete']
+        });
+      }
     }
   }, {
     key: 'componentWillUnmount',
@@ -107,16 +126,16 @@ var ReactCustomGoogleAutocomplete = exports.ReactCustomGoogleAutocomplete = func
   function ReactCustomGoogleAutocomplete(props) {
     _classCallCheck(this, ReactCustomGoogleAutocomplete);
 
-    var _this2 = _possibleConstructorReturn(this, (ReactCustomGoogleAutocomplete.__proto__ || Object.getPrototypeOf(ReactCustomGoogleAutocomplete)).call(this, props));
+    var _this3 = _possibleConstructorReturn(this, (ReactCustomGoogleAutocomplete.__proto__ || Object.getPrototypeOf(ReactCustomGoogleAutocomplete)).call(this, props));
 
-    _this2.service = new google.maps.places.AutocompleteService();
-    return _this2;
+    _this3.service = new google.maps.places.AutocompleteService();
+    return _this3;
   }
 
   _createClass(ReactCustomGoogleAutocomplete, [{
     key: 'onChange',
     value: function onChange(e) {
-      var _this3 = this;
+      var _this4 = this;
 
       var _props$types2 = this.props.types,
           types = _props$types2 === undefined ? ['(cities)'] : _props$types2;
@@ -125,10 +144,10 @@ var ReactCustomGoogleAutocomplete = exports.ReactCustomGoogleAutocomplete = func
       if (e.target.value) {
         this.service.getPlacePredictions({ input: e.target.value, types: types }, function (predictions, status) {
           if (status === 'OK' && predictions && predictions.length > 0) {
-            _this3.props.onOpen(predictions);
+            _this4.props.onOpen(predictions);
             console.log(predictions);
           } else {
-            _this3.props.onClose();
+            _this4.props.onClose();
           }
         });
       } else {
@@ -138,13 +157,13 @@ var ReactCustomGoogleAutocomplete = exports.ReactCustomGoogleAutocomplete = func
   }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
-      var _this4 = this;
+      var _this5 = this;
 
       if (this.props.input.value) {
         this.placeService = new google.maps.places.PlacesService(this.refs.div);
         this.placeService.getDetails({ placeId: this.props.input.value }, function (e, status) {
           if (status === 'OK') {
-            _this4.refs.input.value = e.formatted_address;
+            _this5.refs.input.value = e.formatted_address;
           }
         });
       }
@@ -152,7 +171,7 @@ var ReactCustomGoogleAutocomplete = exports.ReactCustomGoogleAutocomplete = func
   }, {
     key: 'render',
     value: function render() {
-      var _this5 = this;
+      var _this6 = this;
 
       return _react2.default.createElement(
         'div',
@@ -160,7 +179,7 @@ var ReactCustomGoogleAutocomplete = exports.ReactCustomGoogleAutocomplete = func
         _react2.default.cloneElement(this.props.input, _extends({}, this.props, {
           ref: 'input',
           onChange: function onChange(e) {
-            _this5.onChange(e);
+            _this6.onChange(e);
           }
         })),
         _react2.default.createElement('div', { ref: 'div' })

--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,25 @@ export default class ReactGoogleAutocomplete extends React.Component {
       config.componentRestrictions = componentRestrictions;
     }
 
+    this.disableAutofill();
+
     this.autocomplete = new google.maps.places.Autocomplete(this.refs.input, config);
 
     this.event = this.autocomplete.addListener('place_changed', this.onSelected.bind(this));
+  }
+
+  disableAutofill() {
+    // Autofill workaround adapted from https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445
+    if (window.MutationObserver) {
+      const observerHack = new MutationObserver(() => {
+        observerHack.disconnect();
+        this.refs.input.autocomplete = 'disable-autofill';
+      });
+      observerHack.observe(this.refs.input, {
+        attributes: true,
+        attributeFilter: ['autocomplete'],
+      });
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Chrome Autofill ignores the autocomplete="off" attribute that google.maps.places.Autocomplete() add to the address location input.

The workaround suggested in [https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445](https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445) replaces the autocomplete attribute's value by one that doesn't match any key of the Autofill's saved address object, so Chrome doesn't find any value to prefill this input with.

Fix verified in Google Chrome 69 and Microsoft Edge 17. The issue still occurs on Safari 12.