### PR TITLE
Add `fields` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 `npm i react-google-autocomplete --save`
 
-You also have to include google autocomplete link api in your app. Somewhere in index.html or somwehrer else.
+You also have to include google autocomplete link api in your app. Somewhere in index.html or somwhere else.
 
-```
+```html
   <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=[YOUR_API_KEY]&libraries=places"></script>
 ```
 
 ## Example
 
-```
+```js
 import Autocomplete from 'react-google-autocomplete';
 
 <Autocomplete
@@ -31,7 +31,7 @@ The component has one function called `onPlaceSelected`. The function gets invok
 A `types` props means type of places in [google place API](https://developers.google.com/places/web-service/autocomplete#place_types). By default it uses (cities).
 A [componentRestrictions](https://developers.google.com/maps/documentation/javascript/reference#ComponentRestrictions) prop by default is empty.
 A [bounds](https://developers.google.com/maps/documentation/javascript/reference#AutocompleteOptions) prop by default is empty.
-You also can pass any props you want to the final input.
+You also can pass any props you want to the final input. You can also set [fields](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult) prop if you need extra information, now it defaults to basic data in order to control expenses.
 
 ## Contribution
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,16 @@ export default class ReactGoogleAutocomplete extends React.Component {
   }
 
   componentDidMount() {
-    const { types=['(cities)'], componentRestrictions, bounds, } = this.props;
+    const {
+      types=['(cities)'],
+      componentRestrictions,
+      bounds,
+      fields = ["address_components", "geometry.location", "place_id", "formatted_address"]
+    } = this.props;
     const config = {
       types,
       bounds,
+      fields,
     };
 
     if (componentRestrictions) {


### PR DESCRIPTION
Closes #36 

Motivation: by default Google API charges money for additional data.

Added:

- fields config option that can be passed as prop
- minimalist default values, so our users do not get surprised by their bill
- edition of README to reflect that

@ErrorPro Will that be fine, or alternatively should we keep the behavior, just adding the config option?