### PR TITLE
add input ref to onPlaceSelected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ export default class ReactGoogleAutocomplete extends React.Component {
     types: PropTypes.array,
     componentRestrictions: PropTypes.object,
     bounds: PropTypes.object,
-    fields: PropTypes.array,
-  }
+    fields: PropTypes.array
+  };
 
   constructor(props) {
     super(props);
@@ -18,15 +18,20 @@ export default class ReactGoogleAutocomplete extends React.Component {
 
   componentDidMount() {
     const {
-      types=['(cities)'],
+      types = ['(cities)'],
       componentRestrictions,
       bounds,
-      fields = ["address_components", "geometry.location", "place_id", "formatted_address"]
+      fields = [
+        'address_components',
+        'geometry.location',
+        'place_id',
+        'formatted_address'
+      ]
     } = this.props;
     const config = {
       types,
       bounds,
-      fields,
+      fields
     };
 
     if (componentRestrictions) {
@@ -35,9 +40,15 @@ export default class ReactGoogleAutocomplete extends React.Component {
 
     this.disableAutofill();
 
-    this.autocomplete = new google.maps.places.Autocomplete(this.refs.input, config);
+    this.autocomplete = new google.maps.places.Autocomplete(
+      this.refs.input,
+      config
+    );
 
-    this.event = this.autocomplete.addListener('place_changed', this.onSelected.bind(this));
+    this.event = this.autocomplete.addListener(
+      'place_changed',
+      this.onSelected.bind(this)
+    );
   }
 
   disableAutofill() {
@@ -51,7 +62,7 @@ export default class ReactGoogleAutocomplete extends React.Component {
       });
       observerHack.observe(this.refs.input, {
         attributes: true,
-        attributeFilter: ['autocomplete'],
+        attributeFilter: ['autocomplete']
       });
     }
   }
@@ -62,19 +73,20 @@ export default class ReactGoogleAutocomplete extends React.Component {
 
   onSelected() {
     if (this.props.onPlaceSelected) {
-      this.props.onPlaceSelected(this.autocomplete.getPlace());
+      this.props.onPlaceSelected(this.autocomplete.getPlace(), this.refs.input);
     }
   }
 
   render() {
-    const {onPlaceSelected, types, componentRestrictions, bounds, ...rest} = this.props;
+    const {
+      onPlaceSelected,
+      types,
+      componentRestrictions,
+      bounds,
+      ...rest
+    } = this.props;
 
-    return (
-      <input
-        ref="input"
-        {...rest}
-      />
-    );
+    return <input ref="input" {...rest} />;
   }
 }
 
@@ -82,8 +94,8 @@ export class ReactCustomGoogleAutocomplete extends React.Component {
   static propTypes = {
     input: PropTypes.node.isRequired,
     onOpen: PropTypes.func.isRequired,
-    onClose: PropTypes.func.isRequired,
-  }
+    onClose: PropTypes.func.isRequired
+  };
 
   constructor(props) {
     super(props);
@@ -91,46 +103,50 @@ export class ReactCustomGoogleAutocomplete extends React.Component {
   }
 
   onChange(e) {
-    const { types=['(cities)'] } = this.props;
+    const { types = ['(cities)'] } = this.props;
 
-    if(e.target.value) {
-      this.service.getPlacePredictions({input: e.target.value, types}, (predictions, status) => {
-        if (status === 'OK' && predictions && predictions.length > 0) {
-          this.props.onOpen(predictions);
+    if (e.target.value) {
+      this.service.getPlacePredictions(
+        { input: e.target.value, types },
+        (predictions, status) => {
+          if (status === 'OK' && predictions && predictions.length > 0) {
+            this.props.onOpen(predictions);
             console.log(predictions);
-        } else {
-          this.props.onClose();
+          } else {
+            this.props.onClose();
+          }
         }
-      });
+      );
     } else {
       this.props.onClose();
     }
   }
 
-	componentDidMount() {
+  componentDidMount() {
     if (this.props.input.value) {
       this.placeService = new google.maps.places.PlacesService(this.refs.div);
-      this.placeService.getDetails({placeId: this.props.input.value}, (e, status) => {
-        if(status === 'OK') {
-					this.refs.input.value = e.formatted_address;
+      this.placeService.getDetails(
+        { placeId: this.props.input.value },
+        (e, status) => {
+          if (status === 'OK') {
+            this.refs.input.value = e.formatted_address;
+          }
         }
-      });
+      );
     }
   }
 
   render() {
     return (
       <div>
-        {React.cloneElement(this.props.input,
-          {
-            ...this.props,
-    			  ref: 'input',
-            onChange: (e) => {
-              this.onChange(e);
-            },
+        {React.cloneElement(this.props.input, {
+          ...this.props,
+          ref: 'input',
+          onChange: e => {
+            this.onChange(e);
           }
-        )}
-        <div ref="div"></div>
+        })}
+        <div ref="div" />
       </div>
     );
   }


### PR DESCRIPTION
Hi, thank you for the lib, it's very useful for me.

I had one struggle thought, it's very hard to access the text provided by google suggestions, when using formik library, because it's necessary to `setFieldValue` with the input current value on select. But onSelected provides only `place`.

To solve this I've added input ref to onPlaceSelected callback.

```
  onSelected() {
    if (this.props.onPlaceSelected) {
      this.props.onPlaceSelected(this.autocomplete.getPlace(), this.refs.input)
    }
  }
```

To be honest I'm not sure if that's the proper solution, and if there is any other way to access this data. But for me it's working :)

![Screenshot 2019-06-15 at 03 25 19](https://user-images.githubusercontent.com/28235413/59545378-951c6380-8f1d-11e9-80b6-191068aa2af7.png)

![Screenshot 2019-06-15 at 03 25 30](https://user-images.githubusercontent.com/28235413/59545375-8d5cbf00-8f1d-11e9-8099-8d2092823d44.png)


p.s. Also applied default prettier format. Hope it's not a problem.