### PR TITLE
Defensively check for `this.event` on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default class ReactGoogleAutocomplete extends React.Component {
   }
 
   componentWillUnmount() {
-    this.event.remove();
+    if (this.event) this.event.remove();
   }
 
   onSelected() {


### PR DESCRIPTION
We have seen 81 instances of this error in production and have narrowed down the source to this line from our Honeybadger reports.  Hopefully this will help others as well.  

Honeybadger backtrace: 
![image](https://user-images.githubusercontent.com/16197461/63651409-68a57480-c722-11e9-94a1-5d915a173cb4.png)

Thank you for maintaining this project. 
