### PR TITLE
Add inputAutocompleteValue prop to customize autofill disabling solution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ export default class ReactGoogleAutocomplete extends React.Component {
     types: PropTypes.array,
     componentRestrictions: PropTypes.object,
     bounds: PropTypes.object,
-    fields: PropTypes.array
+    fields: PropTypes.array,
+    inputAutocompleteValue: PropTypes.string,
   };
 
   constructor(props) {
@@ -57,7 +58,7 @@ export default class ReactGoogleAutocomplete extends React.Component {
       const observerHack = new MutationObserver(() => {
         observerHack.disconnect();
         if (this.refs && this.refs.input) {
-          this.refs.input.autocomplete = 'off';
+          this.refs.input.autocomplete = this.props.inputAutocompleteValue || 'new-password';
         }
       });
       observerHack.observe(this.refs.input, {
@@ -111,7 +112,6 @@ export class ReactCustomGoogleAutocomplete extends React.Component {
         (predictions, status) => {
           if (status === 'OK' && predictions && predictions.length > 0) {
             this.props.onOpen(predictions);
-            console.log(predictions);
           } else {
             this.props.onClose();
           }


### PR DESCRIPTION
Fixes #70 

Added inputAutocompleteValue prop to allow consuming applications to alter autofill disabling solution as Chrome evolves to ignore web standards in increasingly bold and creative ways. Also updated the default 'off' to 'new-password' as that's what currently works and removed a console.log that probably shouldn't be there 😄

If you aren't a fan of the prop name by all means change it, just looking for a way to control the input `autocomplete` attribute value assigned by the `MutationObserver` hack (`'new-password-${new Date().getTime()}'` appears to do the trick currently).

Thank you for creating this component! It's been a great help 👍 