### PR TITLE
Update docs, fix inputAutocompleteValue dom warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,18 @@
 
 `npm i react-google-autocomplete --save`
 
-You also have to include google autocomplete link api in your app. Somewhere in index.html or somwhere else.
+<hr>
+
+As of version 1.2.4, you can now pass an `apiKey` prop to automatically load the Google maps scripts. The api key can be found in your [google cloud console.](https://developers.google.com/maps/documentation/javascript/get-api-key)
+
+```js
+<AutoComplete
+  apiKey={YOUR_GOOGLE_MAPS_API_KEY}
+  onPlaceSelected={() => 'do something on select'}
+/>
+```
+
+Alternatively if not passing the `apiKey` prop, you can include google autocomplete link api in your app. Somewhere in index.html or somewhere else.
 
 ```html
   <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=[YOUR_API_KEY]&libraries=places"></script>

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,7 +140,8 @@ var ReactGoogleAutocomplete = function (_React$Component) {
           componentRestrictions = _props2.componentRestrictions,
           bounds = _props2.bounds,
           apiKey = _props2.apiKey,
-          rest = _objectWithoutProperties(_props2, ['onPlaceSelected', 'types', 'componentRestrictions', 'bounds', 'apiKey']);
+          inputAutocompleteValue = _props2.inputAutocompleteValue,
+          rest = _objectWithoutProperties(_props2, ['onPlaceSelected', 'types', 'componentRestrictions', 'bounds', 'apiKey', 'inputAutocompleteValue']);
 
       return _react2.default.createElement('input', _extends({ ref: 'input' }, rest));
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-autocomplete",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "React component for google autocomplete.",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -116,6 +116,7 @@ export default class ReactGoogleAutocomplete extends React.Component {
       componentRestrictions,
       bounds,
       apiKey,
+      inputAutocompleteValue,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
- Updated docs with `apiKey` prop example
- Added inputAutocompleteValue to render to prevent prop being passed to input causing dom warning
- Increased version number, compiled new lib build