### PR TITLE
feat: add options to autocomplete constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A `types` props means type of places in [google place API](https://developers.go
 A [componentRestrictions](https://developers.google.com/maps/documentation/javascript/reference#ComponentRestrictions) prop by default is empty.
 A [bounds](https://developers.google.com/maps/documentation/javascript/reference#AutocompleteOptions) prop by default is empty.
 You also can pass any props you want to the final input. You can also set [fields](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult) prop if you need extra information, now it defaults to basic data in order to control expenses.
+The `options`(optional) prop is the optional configuration to your Autocomplete instance. You can see full options [here](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete) 
 
 ## Contribution
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,21 @@ import PropTypes from 'prop-types';
 export default class ReactGoogleAutocomplete extends React.Component {
   static propTypes = {
     onPlaceSelected: PropTypes.func,
-    types: PropTypes.array,
+    types: PropTypes.arrayOf(PropTypes.string),
     componentRestrictions: PropTypes.object,
     bounds: PropTypes.object,
     fields: PropTypes.array,
     inputAutocompleteValue: PropTypes.string,
+    options: PropTypes.shape({
+      componentRestrictions: PropTypes.object,
+      bounds: PropTypes.object,
+      location: PropTypes.object,
+      offset: PropTypes.number,
+      origin: PropTypes.object,
+      radius: PropTypes.number,
+      sessionToken: PropTypes.object,
+      types: PropTypes.arrayOf(PropTypes.string)
+    }),
   };
 
   constructor(props) {
@@ -27,9 +37,11 @@ export default class ReactGoogleAutocomplete extends React.Component {
         'geometry.location',
         'place_id',
         'formatted_address'
-      ]
+      ],
+      options = {}
     } = this.props;
     const config = {
+      ...options,
       types,
       bounds,
       fields
@@ -84,6 +96,7 @@ export default class ReactGoogleAutocomplete extends React.Component {
       types,
       componentRestrictions,
       bounds,
+      options,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
option to be used in autocomplete constructor.
see more about [here](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete)

resolves #72 