### PR TITLE
Renaming wrong documentation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ import usePlacesService from "react-google-autocomplete/lib/usePlacesAutocomplet
 
 export default () => {
   const { placePredictions, getPlacePredictions, isPlacePredictionsLoading } =
-    useGoogle({
+    usePlacesService({
       apiKey: process.env.REACT_APP_GOOGLE,
     });
 


### PR DESCRIPTION
I was reading the documentation and found this.