### PR TITLE
Adding missing square

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ var loadGoogleMapScript = function loadGoogleMapScript(googleMapsScriptBaseUrl, 
     if (google.maps && google.maps.api) return Promise.resolve();
   }
 
-  var scriptElements = document.querySelectorAll("script[src*=\"".concat(googleMapsScriptBaseUrl, "\""));
+  var scriptElements = document.querySelectorAll("script[src*=\"".concat(googleMapsScriptBaseUrl, "\"]"));
 
   if (scriptElements && scriptElements.length) {
     return new Promise(function (resolve) {


### PR DESCRIPTION
![ios12safarierror](https://user-images.githubusercontent.com/11632527/137284534-199b7397-8a52-467a-931d-4a200a8228c5.png)

It's a problem on iOS 12 with safari.
I had to add the closing ] on the pattern of querySelectorAll to avoid that problem.