### PR TITLE
fix: TypeError: Cannot set properties of null (setting 'autocomplete')

### DIFF
--- a/src/usePlacesWidget.js
+++ b/src/usePlacesWidget.js
@@ -104,7 +104,9 @@ export default function usePlacesWidget(props) {
       observerHack.current = new MutationObserver(() => {
         observerHack.current.disconnect();
 
-        inputRef.current.autocomplete = inputAutocompleteValue;
+        if (inputRef.current) {
+          inputRef.current.autocomplete = inputAutocompleteValue;
+        }
       });
       observerHack.current.observe(inputRef.current, {
         attributes: true,


### PR DESCRIPTION
Currently, when registering `MutationObserver` there's no explicit check if ref still exists. This can be problematic when you work for example with conditional fields, and field is no longer rendered or haven't fully rendered yet.

This should fix this.