### PR TITLE
fix: addListener is not a function

### DIFF
--- a/src/usePlacesWidget.js
+++ b/src/usePlacesWidget.js
@@ -69,19 +69,21 @@ export default function usePlacesWidget(props) {
         inputRef.current,
         config
       );
-
-      event.current = autocompleteRef.current.addListener(
-        "place_changed",
-        () => {
-          if (onPlaceSelected && autocompleteRef && autocompleteRef.current) {
-            onPlaceSelected(
-              autocompleteRef.current.getPlace(),
-              inputRef.current,
-              autocompleteRef.current
-            );
+      
+      if(autocompleteRef.current) {
+         event.current = autocompleteRef.current.addListener(
+          "place_changed",
+          () => {
+            if (onPlaceSelected && autocompleteRef && autocompleteRef.current) {
+              onPlaceSelected(
+                autocompleteRef.current.getPlace(),
+                inputRef.current,
+                autocompleteRef.current
+              );
+            }
           }
-        }
-      );
+        );
+      }
     };
 
     if (apiKey) {


### PR DESCRIPTION
Error handling for the case:
TypeError: autocompleteRef.current.addListener is not a function

Funcitonality works fine, but test cases failiing on feature implemented areas because autocompleteRef.current returning null initially, so added this error handling code