### PR TITLE
Fix instanceof check

### DIFF
--- a/lib/usePlacesWidget.js
+++ b/lib/usePlacesWidget.js
@@ -77,7 +77,7 @@ function usePlacesWidget(props) {
 
       if (typeof google === "undefined") return console.error("Google has not been found. Make sure your provide apiKey prop.");
       if (!((_google$maps = google.maps) !== null && _google$maps !== void 0 && _google$maps.places)) return console.error("Google maps places API must be loaded.");
-      if (!inputRef.current instanceof HTMLInputElement) return console.error("Input ref must be HTMLInputElement.");
+      if (!(inputRef.current instanceof HTMLInputElement)) return console.error("Input ref must be HTMLInputElement.");
       autocompleteRef.current = new google.maps.places.Autocomplete(inputRef.current, config);
 
       if (autocompleteRef.current) {

--- a/src/usePlacesWidget.js
+++ b/src/usePlacesWidget.js
@@ -62,7 +62,7 @@ export default function usePlacesWidget(props) {
       if (!google.maps?.places)
         return console.error("Google maps places API must be loaded.");
 
-      if (!inputRef.current instanceof HTMLInputElement)
+      if (!(inputRef.current instanceof HTMLInputElement))
         return console.error("Input ref must be HTMLInputElement.");
 
       autocompleteRef.current = new google.maps.places.Autocomplete(


### PR DESCRIPTION
I think there is an issue in the instanceof check.

I keep getting an warning message like this in my bundler where imported this library:

```
▲ [WARNING] Suspicious use of the "!" operator inside the "instanceof" operator [suspicious-boolean-not]
    .wrangler/tmp/pages-GVXi9w/bundledWorker-0.2874780651986786.mjs:31392:16:
      31392 │             if (!inputRef.current instanceof HTMLInputElement)
            │                 ~~~~~~~~~~~~~~~~~
            ╵                 (!inputRef.current)
```

Right now `!inputRef.current` is evaluated first to either `true` or `false`, and `true instanceof HTMLInputElement` and `false instanceof HTMLInputElement` would both evaluate to `false`, so I think this code will not trigger at all at the moment.

For extra confirmation I tried plugging it into ASTExplorer which also showed that `!inputRef.current` is evaluated as one unit:

![image](https://github.com/ErrorPro/react-google-autocomplete/assets/353863/1efaa069-ed4b-4ece-a75f-7d8d463c1318)

I just created this PR in the GitHub web interface, not sure if that will suffice to be ready to merge. Let me know if you'd need anything from me. Thanks!