### PR TITLE
Reassign event listener when onPlaceSelected changes

### DIFF
--- a/lib/usePlacesWidget.js
+++ b/lib/usePlacesWidget.js
@@ -100,7 +100,20 @@ function usePlacesWidget(props) {
     return function () {
       return event.current ? event.current.remove() : undefined;
     };
-  }, []); // Autofill workaround adapted from https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445
+  }, []);
+  (0, _react.useEffect)(function () {
+    if (autocompleteRef.current && onPlaceSelected) {
+      event.current = autocompleteRef.current.addListener("place_changed", function () {
+        if (onPlaceSelected && autocompleteRef && autocompleteRef.current) {
+          onPlaceSelected(autocompleteRef.current.getPlace(), inputRef.current, autocompleteRef.current);
+        }
+      });
+    }
+
+    return function () {
+      return event.current ? event.current.remove() : undefined;
+    };
+  }, [onPlaceSelected]); // Autofill workaround adapted from https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445
 
   (0, _react.useEffect)(function () {
     var _React$version;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-google-autocomplete",
-  "version": "2.7.2",
+  "version": "2.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-google-autocomplete",
-      "version": "2.7.2",
+      "version": "2.7.4",
       "license": "ISC",
       "dependencies": {
         "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-google-autocomplete",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "React component for google autocomplete.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/usePlacesWidget.js
+++ b/src/usePlacesWidget.js
@@ -95,6 +95,17 @@ export default function usePlacesWidget(props) {
     return () => (event.current ? event.current.remove() : undefined);
   }, []);
 
+  useEffect(() => {
+    if (autocompleteRef.current && onPlaceSelected) {
+      event.current = autocompleteRef.current.addListener("place_changed", function () {
+        if (onPlaceSelected && autocompleteRef && autocompleteRef.current) {
+          onPlaceSelected(autocompleteRef.current.getPlace(), inputRef.current, autocompleteRef.current);
+        }
+      });
+    }
+    return () => (event.current ? event.current.remove() : undefined);
+  }, [onPlaceSelected]);
+
   // Autofill workaround adapted from https://stackoverflow.com/questions/29931712/chrome-autofill-covers-autocomplete-for-google-maps-api-v3/49161445#49161445
   useEffect(() => {
     // TODO find out why react 18(strict mode) hangs the page loading


### PR DESCRIPTION
I found that when `onPlaceSelected` handler has some dependencies, which can be change through the time - `usePlacesWidget` still calls the old version of `onPlaceSelected`. 

Reassigning the event listener helps resolve this issue.

