### PR TITLE
Added check for `google.maps` in script loader when script element already exists

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ var loadGoogleMapScript = function loadGoogleMapScript(googleMapsScriptBaseUrl, 
   if (scriptElements && scriptElements.length) {
     return new Promise(function (resolve) {
       // in case we already have a script on the page and it's loaded we resolve
-      if (typeof google !== "undefined") return resolve(); // otherwise we wait until it's loaded and resolve
+      if (typeof google !== "undefined" && google.maps) return resolve(); // otherwise we wait until it's loaded and resolve
 
       scriptElements[0].addEventListener("load", function () {
         return resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-google-autocomplete",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-google-autocomplete",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "ISC",
       "dependencies": {
         "lodash.debounce": "^4.0.8",

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ export const loadGoogleMapScript = (
   if (scriptElements && scriptElements.length) {
     return new Promise((resolve) => {
       // in case we already have a script on the page and it's loaded we resolve
-      if (typeof google !== "undefined") return resolve();
+      if (typeof google !== "undefined" && google.maps) return resolve();
 
       // otherwise we wait until it's loaded and resolve
       scriptElements[0].addEventListener("load", () => resolve());


### PR DESCRIPTION
Got same error as in issue #176 

After some research found that this error appears when we have 2 components that use the `usePlacesAutocompleteService` hook. and it appears only for the 2nd component.

this is caused because on the 2nd load of the component, the google API is partially loaded, and we have `google` on the global scope, but we still don't have the `google.maps` object.

adding a check that `google.maps` object exists seem to solve this issue